### PR TITLE
Several improvements

### DIFF
--- a/features/bed_mesh/bed.cfg
+++ b/features/bed_mesh/bed.cfg
@@ -1,0 +1,37 @@
+[respond]
+
+[gcode_macro BED_MESH_CALIBRATE]
+rename_existing: _BED_MESH_CALIBRATE_OG
+gcode:
+  {% set BED_TEMP = params.BED_TEMP|default(60)|float %}
+  {% set CHAMBER_TEMP = params.CHAMBER_TEMP|default(0)|float %}
+  {% set SOAK_TIME = params.SOAK_TIME|default(5)|float %}
+  ## make this configurable
+  {% set EXTRUDER_WAITTEMP = (140.0|float)|int %}
+
+  {% if not 'xyz' in printer.toolhead.homed_axes %}
+    G28
+  {% endif %}
+
+  M104 S{EXTRUDER_WAITTEMP}
+  M190 S{BED_TEMP}
+  M109 S{EXTRUDER_WAITTEMP}
+
+  {% if CHAMBER_TEMP > 0 %}
+    M191 S{CHAMBER_TEMP}
+  {% endif %}
+
+  RESPOND MSG="Soaking for {SOAK_TIME} minutes ..."
+  M117 Heat soaking
+  G4 P{60000 * SOAK_TIME} # x minute heat soak
+
+  # ensure bed is level
+  # some users have reported that the bed does not raise uniformly from the bottom
+  Z_TILT_ADJUST
+  # rehome Z after tilt adjust
+  G28 Z
+
+  BOX_NOZZLE_CLEAN
+
+  M117 Bed meshing
+  _BED_MESH_CALIBRATE_OG PROFILE={BED_TEMP}c_{CHAMBER_TEMP}c

--- a/features/chamber/m191.cfg
+++ b/features/chamber/m191.cfg
@@ -18,7 +18,7 @@ gcode:
               G28
             {% endif %}
             G1 Z5 F600
-            {% if printer.heater_bed.target > 100.0 %}
+            {% if printer.heater_bed.target > 99.0 %}
               RESPOND MSG="Bed target temp already high enough, not changing ..."
             {% else %}
               RESPOND MSG="Bed target temp not high enough, setting to 105c ..."

--- a/features/start_print/start_print.cfg
+++ b/features/start_print/start_print.cfg
@@ -1,15 +1,46 @@
 [gcode_macro START_PRINT]
+# be sure to update your slicer to pass in both chamber temp and material type, for Creality Print:
+# START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] CHAMBER_TEMP=[overall_chamber_temperature] MATERIAL={filament_type[initial_tool]}
 variable_prepare: 0
 gcode:
+  M117 START_PRINT
   BOX_START_PRINT  # what exactly does this do?
   G90
-  SET_GCODE_OFFSET Z=0
   {% set BED_TEMP = params.BED_TEMP|default(60)|float %}
   {% set CHAMBER_TEMP = params.CHAMBER_TEMP|default(0)|float %}
   {% set EXTRUDER_TEMP = params.EXTRUDER_TEMP|default(220)|float %}
   {% set EXTRUDER_WAITTEMP = (140.0|float)|int %}
+  {% set MATERIAL = params.MATERIAL|default('')|string %}
 
-  M117 START_PRINT
+  #######################################
+  # !!! set your material offset here !!!
+  #######################################
+  {% if MATERIAL == 'PLA' %}
+    {% set OFFSET = 0.00 %}
+  {% elif MATERIAL == 'PETG' %}
+    {% set OFFSET = 0.00 %}
+  {% elif MATERIAL == 'ASA' %}
+    {% set OFFSET = 0.00 %}
+  {% else %}
+    # default value
+    {% set OFFSET = 0.00 %}
+  {% endif %}
+  RESPOND MSG="Setting Z offset for {MATERIAL} of {OFFSET} ..."
+  SET_GCODE_OFFSET Z={OFFSET}
+
+  {% if not 'xyz' in printer.toolhead.homed_axes %}
+    G28
+  {% endif %}
+  # ensure bed is level
+  # some users have reported that the bed does not raise uniformly from the bottom
+  Z_TILT_ADJUST
+  # rehome Z after tilt adjust
+  G28 Z
+
+  {% if CHAMBER_TEMP > 0 %}
+    M141 S{CHAMBER_TEMP}
+  {% endif %}
+
   # when is a print prepared?
   {% if printer['gcode_macro START_PRINT'].prepare|int == 0 %}
     {action_respond_info("print prepared 111")}
@@ -17,7 +48,6 @@ gcode:
     M140 S{BED_TEMP}
     M104 S{EXTRUDER_WAITTEMP}
     SET_VELOCITY_LIMIT ACCEL=5000 ACCEL_TO_DECEL=5000
-    G28
     NOZZLE_CLEAR
     M104 S{EXTRUDER_WAITTEMP}
     M190 S{BED_TEMP}
@@ -32,27 +62,43 @@ gcode:
     PRINT_PREPARE_CLEAR
   {% endif %}
 
-  # don't want to accidently turn off chamber heating if a parameter wasn't passed in
+  # !!! this MUST come after all G28s as they reset the mesh to "default"
+  # load the mesh for the current bed and chamber temp
+  RESPOND MSG="Loading bed mesh: {BED_TEMP}c_{CHAMBER_TEMP}c ..."
+  BED_MESH_PROFILE LOAD={BED_TEMP}c_{CHAMBER_TEMP}c
+  M117 MESH: {BED_TEMP}c_{CHAMBER_TEMP}c
+
+  # don't want to accidently turn off chamber heating if a temp wasn't passed in
   {% if CHAMBER_TEMP > 0 %}
     M191 S{CHAMBER_TEMP}
+    G4 P{60000 * 5} # five minute heat soak
   {% endif %}
 
-  # ensure bed is level
-  # some users have reported that the bed does not raise uniformly from the bottom
-  Z_TILT_ADJUST
-
-  M104 S{EXTRUDER_TEMP}
-  # G1 Z5 F600
-  BOX_GO_TO_EXTRUDE_POS#M1500
-  M109 S{EXTRUDER_TEMP} ;wait nozzle heating
+  M109 S{EXTRUDER_WAITTEMP}
 
   # Ensure bed is at the desired temp
   # works around some firmware bugs that sometimes turn off the bed
   M190 S{BED_TEMP}
+
   # as with the bed, really ensure we are at chamber temp
   {% if CHAMBER_TEMP > 0 %}
     M191 S{CHAMBER_TEMP}
   {% endif %}
+
+  BOX_GO_TO_EXTRUDE_POS#M1500
+  M109 S{EXTRUDER_TEMP} ;wait nozzle heating
+
+  # the stock chamber heater configuration is watermark
+  # which means at best it will reach the target temp, but rarely exceed it
+  # for materials like ASA the chamber temp should be a _minimum_
+  {% if CHAMBER_TEMP > 0 %}
+    {% if CHAMBER_TEMP + 5 <= 60 %}
+      M141 S{CHAMBER_TEMP + 5}
+    {% else %}
+      M141 S60
+    {% endif %}
+  {% endif %}
+
   M220 S100 ;Reset Feedrate
   # M221 S100 ;Reset Flowrate
   G21


### PR DESCRIPTION
M191 macro
* lowered bed temp check in M191 to 99c

BED_MESH_CALIBRATE macro
* added parameters for BED and CHAMBER temps
* added parameter for desired soak time, in minutes
* store mesh based on BED and CHAMBER temp
* ensures nozzle is wiped
* ensures bed is level (Z_TILT_ADJUST)

START_PRINT macro
* filament based z offsets
* automatic loading of temperature based bed meshes
* better chamber heating logic