### PR TITLE
Adding OctoEverywhere To The Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Sadly, many of the K2 beds resemble a taco or valley.  In the [bed_leveling](bed
 * Fluidd - https://github.com/fluidd-core/fluidd
 * Entware - https://github.com/Entware/Entware
 * Obico - https://www.obico.io/
+* OctoEverywhere - https://www.octoeverywhere.com
 
 ## Fluidd / K2 Webcam
 

--- a/entware/menu.sh
+++ b/entware/menu.sh
@@ -133,6 +133,22 @@ install_option_3() {
     cd $cur_dir
 }
 
+install_option_4() {
+    entry_name="OctoEverywhere"
+    require 1
+    require 2
+    printf "Installing ${entry_name}...\n"
+    ensure_entware_in_path
+    cur_dir=$(pwd)
+    cd /mnt/UDISK
+    git clone https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere.git octoeverywhere
+    cd octoeverywhere
+    ./install.sh
+    printf "${entry_name} installed.\n"
+    /etc/init.d/octoeverywhere_service restart
+    cd $cur_dir
+}
+
 # Display menu
 show_menu() {
     clear_screen
@@ -165,6 +181,14 @@ show_menu() {
         printf "3) ${entry_name}\n"
     fi
 
+    # Option 4
+    entry_name="OctoEverywhere"
+    if is_installed "4"; then
+        printf "4) %b[INSTALLED]%b ${entry_name}\n" "$GREEN" "$NC"
+    else
+        printf "4) ${entry_name}\n"
+    fi
+
     printf "%b============================================%b\n" "$BLUE" "$NC"
     printf "a) Install all\n"
     printf "%b============================================%b\n" "$BLUE" "$NC"
@@ -180,7 +204,7 @@ show_menu() {
 # Main menu loop
 while true; do
     show_menu
-    printf "Please enter your choice %b[1-3, a or q]%b: " "$YELLOW" "$NC"
+    printf "Please enter your choice %b[1-4, a or q]%b: " "$YELLOW" "$NC"
     read choice
 
     case "$choice" in
@@ -190,7 +214,7 @@ while true; do
             read dummy
             continue
             ;;
-        1|3)
+        1|4)
             if is_installed "$choice"; then
                 printf "%bThis option is already installed.%b\n" "$YELLOW" "$NC"
                 printf "Press Enter to continue..."
@@ -207,7 +231,7 @@ while true; do
             ;;
         a|A)
             clear_screen
-            for i in $(seq 1 3); do
+            for i in $(seq 1 4); do
                 "install_option_$i"
                 mark_installed "$i"
             done

--- a/menu.sh
+++ b/menu.sh
@@ -130,7 +130,7 @@ install_option_2() {
     # Split first three components
     major_minor_patch=$(echo "$version" | cut -d'.' -f1-3)
 
-    if [ "$major_minor_patch" \>= "1.1.2" ]; then
+    if expr "$major_minor_patch" \>= "1.1.2" >/dev/null 2>&1; then
         printf "Not installing ${entry_name}, no longer needed ...\n"
     else
         printf "Installing ${entry_name}...\n"


### PR DESCRIPTION
Thanks for this wonderful set of scripts! 

I have been working with my community to make the OctoEverywhere installer compatible with the K2, and we just released the first pass! Many community members have asked if they can install OctoEverywhere via your script, so I added it as a menu option.

The OctoEverywhere `install.sh` script should do all of the work required once the git repo is cloned. There shouldn't be any need for patches or changes to the repo. But if there is an issue, please let me know, and I will fix it ASAP!

