### PR TITLE
Add Mac installation guide for Cartographer firmware

### DIFF
--- a/features/cartographer/firmware/README.md
+++ b/features/cartographer/firmware/README.md
@@ -41,3 +41,31 @@ The Windows installation is a modified version of the above provided by bigadz a
 5. Run the script by entering `bash ./WSLFlash.sh` in the terminal and hitting enter
 
 The script should automatically do everything and leave you with a flashed Cartographer.
+
+## Mac Install
+The Mac process is utilizes the Linux method with a Virtual Machine in order to prevent poluting the local environment. VMWare Fusion is [now free for personal use](https://blogs.vmware.com/teamfusion/2024/05/fusion-pro-now-available-free-for-personal-use.html) so this guide utilizes that.
+
+Setup:
+1. [Install VMWare Fusion](https://www.vmware.com/products/desktop-hypervisor/workstation-and-fusion) (you will need to create an account)
+2. Download and install a arm64 [Ubuntu Server image](https://ubuntu.com/download/server/arm) as a VMWare Guest
+3. Power off the guest when finished.
+
+When flashing the Cartographer, the Cartographer will reboot and re-connect to USB. The scripts try to account for this with sleep commands but in my case the sleep commands were not enough. Modify the USB settings for the VM so that all newly connected USB devices get automatically connected to the VM:
+1. VM Guest Settings > USB > Advanced USB Options
+2. Set the "When a new USB device is plugged into this Mac while this virtual machine is running, VMWare" dropdown to `Connect to this virtual machine`
+
+Cartographer Flashing:
+1. Power up the VM and login.
+2. Connect the Cartographer to USB
+3. Verify that an `OpenMoko` device is present when running `lsusb`
+4. Download the script by running the following in the terminal:
+
+    ```bash
+    wget https://raw.githubusercontent.com/jamincollins/k2-improvements/refs/heads/main/features/cartographer/firmware/flash.sh
+    ```
+
+5. Run script by entering `bash ./flash.sh` in the terminal and hitting enter
+
+The script should automatically do everything and leave you with a flashed Cartographer.
+
+If the script fails due to not being able to find the Cartographer, etc, you can unplug the Cartographer, wait a few moments, plug it back in and try again. You may need to increase the duration for or add more sleep statements to the bottom of the script.


### PR DESCRIPTION
This update provides detailed instructions for flashing the Cartographer firmware on Mac using VMWare Fusion with an Ubuntu VM. It includes setup steps, USB configuration tips, and troubleshooting guidance for potential script issues.