### PR TITLE
Adding OctoEverywhere To The Installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Donations are definitely _not required_, they are appreciated.  If you'd like to
 * updated [Fluidd](./features/fluidd/README.md)
 * updated [Moonraker](./features/moonraker/README.md)
 * [Obico](./features/obico/README.md) - _WIP_
+* [OctoEverywhere](./features/octoeverywhere/README.md) - Remote Access, AI Failure Detection, Print Notifications
 * implements [SCREWS_TILT_CALCULATE](https://www.klipper3d.org/Manual_Level.html#adjusting-bed-leveling-screws-using-the-bed-probe)
 
 And a few quality of life improvement macros
@@ -83,6 +84,7 @@ Sadly, many of the K2 beds resemble a taco or valley.  In the [bed_leveling](bed
 * Entware - [https://github.com/Entware/Entware](https://github.com/Entware/Entware)
 * Obico - [https://www.obico.io/](https://www.obico.io/)
 * SimplyPrint - [https://simplyprint.io/](https://simplyprint.io/)
+* OctoEverywhere - [https://octoeverywhere.com/](https://octoeverywhere.com/)
 
 ## FAQ
 

--- a/features/octoeverywhere/README.md
+++ b/features/octoeverywhere/README.md
@@ -1,0 +1,7 @@
+# OctoEverywhere
+
+## Why
+
+OctoEverywhere is a 3D printing community project that enables free & unlimited remote access, AI failure detection, print notifications, live streaming, and more!
+
+Learn more at [OctoEverywhere.com](https://octoeverywhere.com)

--- a/features/octoeverywhere/install.sh
+++ b/features/octoeverywhere/install.sh
@@ -1,0 +1,17 @@
+#!/bin/ash
+
+set -e
+
+cd ${HOME}
+
+# Only pull the repo if it doesn't exist.
+[ -d "./octoeverywhere" ] && echo "OctoEverywhere repo already exists, skipping clone." || git clone https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere.git octoeverywhere
+cd octoeverywhere
+
+# Ensure we have the most recent bits.
+git fetch --all
+git reset --hard origin/master
+git pull
+
+# Run the installer, it will handle all of the K2 special logic.
+sh ./install.sh


### PR DESCRIPTION
This PR adds the OctoEverywhere installer script to the features folder.

This is a follow-up to the last PR (https://github.com/jamincollins/k2-improvements/pull/14) which was based on the old logic. I just my K2 the other day, so I was able to fully get things working and test all of the install scripts.

Let me know if I need to make any changes!