### PR TITLE
Improvements: screws_tilt_adjust - added a fixed reference point in center of bed

### DIFF
--- a/features/bed_screws/bed.cfg
+++ b/features/bed_screws/bed.cfg
@@ -8,6 +8,7 @@ gcode:
 [screws_tilt_adjust]
 screw1: 175, 175
 screw1_name: Home
+#Added Cenetr of K2 Bed for Reference to adjust all 4 screws to the Bed instead of 3 of the screws to the first screw in the list
 screw2: 45, 28
 screw2_name: Front Left
 screw3: 307, 28

--- a/features/bed_screws/bed.cfg
+++ b/features/bed_screws/bed.cfg
@@ -6,14 +6,16 @@ gcode:
     _OG_SCREWS_TILT_CALCULATE
 
 [screws_tilt_adjust]
-screw1: 45, 28
-screw1_name: Front Left
-screw2: 307, 28
-screw2_name: Front Right
-screw3: 307, 314
-screw3_name: Rear Right
-screw4: 45, 314
-screw4_name: Rear Left
+screw1: 175, 175
+screw1_name: Home
+screw2: 45, 28
+screw2_name: Front Left
+screw3: 307, 28
+screw3_name: Front Right
+screw4: 307, 314
+screw4_name: Rear Right
+screw5: 45, 314
+screw5_name: Rear Left
 speed: 150
 horizontal_move_z: 10
-screw_thread: CW-M4
+screw_thread: CW-M

--- a/features/cfs/box/box.cfg
+++ b/features/cfs/box/box.cfg
@@ -1,0 +1,104 @@
+# Updates to Box.cfg by Scott Evans
+# https://github.com/QuackenAudio
+
+# Changes made to alleviate Filament Loading/Unloading issues Caused by interaction of CFS 4x1 and Extruder
+# All Chinese Symbols have been converted to Englisgh Text by Google Translate
+
+[serial_485 serial485]
+serial: /dev/ttyS5
+baud: 230400
+
+[auto_addr]
+
+[filament_rack]
+not_pin: !PA5
+
+[box]
+bus:serial485
+filament_sensor:filament_sensor
+pre_cut_pos_x: 10 #Pre-cut knife position, ensure vertical cut
+pre_cut_pos_y: 200
+cut_pos_y: 200 #middle_cut_pos_y:
+Tn_retrude: -20 #Stock Value: -10  #After cutting, the length of the consumables to exit the extrusion gear
+#Tn_retrude value gets the filament completely out of the Extruder
+Tn_retrude_velocity: 360 #Stock Value 600 #Retraction speed
+#Tn_retrude_velocity new speed doesnt try to go faster than the filament can actually move
+Tn_extrude_temp: 240 #Extrusion temperature
+Tn_extrude: 20 #If the current temperature is set, preheat the knife 120
+Tn_extrude_velocity: 360   #360 #Extrusion speed
+buffer_empty_len: 10 #30 #Buffer retraction reserved length, the length reserved for the extrusion buffer (The length from the collision knife in the extruder to the extrusion gear)
+#buffer_empty_len this is distance after the filament sensor to stop teh filament, preventing ramming, which leads to the CFS grinding the Filament because it cant push it further
+clean_left_pos_x: 135 #The trough swings after the material is spitted out. Left boundary
+clean_left_pos_y: 378
+clean_right_pos_x: 160 #The trough swings after the material is spitted out. Right boundary
+clean_right_pos_y: 378
+clean_velocity: 12000
+box_need_clean_length:70
+cut_velocity: 30000
+extrude_pos_x: 133 #Switch the position of material spitting
+extrude_pos_y: 378
+has_extrude_pos: 1 #Is there any need to spit out material? Distinguish between K1_MAX and f008
+safe_pos_y: 345
+safe_pos_x: 225
+clean_pos_left_x: 160 #The coordinates of the left boundary of the wipe nozzle silicone
+clean_pos_right_x:170 #The coordinates of the right boundary of the wipe nozzle silicone
+clean_pos_middle_y:374 #The Y-axis middle coordinate of the wipe nozzle silicone
+check_cut_pos_x_max:-7 #Stock Value -5 #The boundary value of the maximum coordinate of the cutter calibration coordinate
+#check_cut_pos_x_max this slightly higher value allows for the filament to fully get cut - stock value was a little too conservative and sometimes didnt fully cut filament
+switch_pin:!nozzle_mcu:PB9
+version: 1
+
+[load_ai]
+
+[gcode_macro BOX_CHECK_MATERIAL]
+gcode:
+
+[gcode_macro BOX_LOAD_MATERIAL_WITH_MATERIAL]
+gcode:
+  BOX_CHECK_MATERIAL
+  BOX_CUT_MATERIAL
+  BOX_SAVE_FAN
+  BOX_RETRUDE_MATERIAL_WITH_TNN # BOX_RETRUDE_MATERIAL
+  BOX_EXTRUDE_MATERIAL
+  BOX_EXTRUDER_EXTRUDE
+  BOX_MATERIAL_CHANGE_FLUSH # BOX_MATERIAL_FLUSH
+  BOX_RESTORE_FAN
+  BOX_MOVE_TO_SAFE_POS
+
+[gcode_macro BOX_LOAD_MATERIAL_WITHOUT_MATERIAL]
+gcode:
+  M104
+  BOX_CHECK_MATERIAL
+  BOX_EXTRUDE_MATERIAL
+  BOX_EXTRUDER_EXTRUDE
+  BOX_MATERIAL_CHANGE_FLUSH # BOX_MATERIAL_FLUSH
+
+[gcode_macro BOX_RETRUDE_MATERIAL_WITH_TNN]
+rename_existing: BOX_RETRUDE_MATERIAL_WITH_TNN1
+gcode:
+  BOX_SET_TEMP
+  BOX_GO_TO_EXTRUDE_POS
+  BOX_RETRUDE_MATERIAL
+
+[gcode_macro BOX_QUIT_MATERIAL]
+gcode:
+  BOX_CHECK_MATERIAL
+  BOX_CUT_MATERIAL
+  BOX_RETRUDE_MATERIAL_WITH_TNN
+  BOX_MOVE_TO_SAFE_POS
+
+# eg:
+# BOX_EXTRUDE_MATERIAL TNN=T1A
+# BOX_EXTRUDER_EXTRUDE TNN=T1A
+# BOX_MATERIAL_FLUSH LEN=100 VELOCITY=360 TEMP=220
+# BOX_RETRUDE_MATERIAL_WITH_TNN TNN=T1A
+
+[gcode_macro BOX_INFO_REFRESH]
+gcode:
+  BOX_SET_PRE_LOADING ADDR={params.ADDR} NUM={params.NUM} ACTION=RUN
+  M400
+  BOX_GET_RFID ADDR={params.ADDR} NUM={params.NUM}
+  M400
+  BOX_GET_REMAIN_LEN ADDR={params.ADDR} NUM={params.NUM}
+  M400
+


### PR DESCRIPTION
added a fixed point in the center of the bed for this macro
this allows you to move all screws to the bed center instead of moving 3 screws to the 4th location
makes it so that you center on the bed instead of just on 1 screw that might be high or low to start with