### PR TITLE
Update start_print.cfg

### DIFF
--- a/features/macros/start_print/start_print.cfg
+++ b/features/macros/start_print/start_print.cfg
@@ -11,7 +11,7 @@ variable_offset_PETG: 0
 variable_offset_ABS: 0
 variable_offset_ASA: 0
 variable_offset_DEFAULT: 0
-variable_offset_PROBE: 0
+variable_offset_PROBE: 1 #change this to 0 if you want to set your own z offsets above, leave it at 1 if you want the printer to set the z offset using the nozzle to tap the plate.
 variable_heat_soak: 5 # minutes
 gcode:
 


### PR DESCRIPTION
made variable_offset_PROBE default to 1 so z offsets are automatic by default, and added a note about the binary 1 and 0 settings.