### PR TITLE
Add Filament-Sync-Service feature install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Donations are definitely _not required_, they are appreciated.  If you'd like to
 * [better init](./features/better-init/README.md)
 * [better root](./features/better-root/README.md) home directory
 * [Cartographer](./features/cartographer/README.md) support
+* [Filament-Sync](https://github.com/HurricanePrint/Filament-Sync) Sync custom filaments to printer for use with RFID tags
 * installs [Entware](https://github.com/Entware/Entware)
 * updated [Fluidd](./features/fluidd/README.md)
 * updated [Moonraker](./features/moonraker/README.md)
@@ -81,7 +82,7 @@ Sadly, many of the K2 beds resemble a taco or valley.  In the [bed_leveling](bed
 * [@Guilouz](https://github.com/Guilouz) - standing on the shoulders of giants
 * [@stranula](https://github.com/stranula)
 * [@juliosueiras](https://github.com/juliosueiras)
-
+* [@HurricanePrint](https://github.com/HurricanePrint)
 * Moonraker - [https://github.com/Arksine/moonraker](https://github.com/Arksine/moonraker)
 * Klipper - [https://github.com/Klipper3d/klipper](https://github.com/Klipper3d/klipper)
 * Fluidd - [https://github.com/fluidd-core/fluidd](https://github.com/fluidd-core/fluidd)

--- a/features/filament-sync-service/install.sh
+++ b/features/filament-sync-service/install.sh
@@ -1,0 +1,6 @@
+cd ${HOME}
+
+git clone https://github.com/HurricanePrint/Filament-Sync-Service.git
+cd Filament-Sync-Service
+
+sh install.sh

--- a/gimme-the-jamin.sh
+++ b/gimme-the-jamin.sh
@@ -18,6 +18,7 @@ install_feature moonraker
 install_feature fluidd
 install_feature screws_tilt_adjust
 install_feature cartographer
+install_feature filament-sync-service
 mkdir -p /tmp/macros
 install_feature macros/bed_mesh
 install_feature macros/m191

--- a/no-carto.sh
+++ b/no-carto.sh
@@ -18,6 +18,7 @@ install_feature moonraker
 install_feature fluidd
 install_feature screws_tilt_adjust
 #install_feature cartographer
+install_feature filament-sync-service
 mkdir -p /tmp/macros
 install_feature macros/bed_mesh
 install_feature macros/m191


### PR DESCRIPTION
Added feature install script to install backend service for [Filament-Sync](https://github.com/HurricanePrint/Filament-Sync). This service copies custom filament database/options json files to the creality directories on boot and when syncing from the main tool either manually or as a post-processing script in the slicer. Allows custom filaments to be added into the printers filament selection screen for use with and without custom RFID tags. Using custom tags will automatically select the correct filament settings, brand, material type, color, and show filament usage on the OSD.